### PR TITLE
Relax text bound - allow 2.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,7 @@ library:
     - containers >= 0.6.0.1 && < 0.7
     - megaparsec >= 7.0.5 && < 9.3
     - parser-combinators >= 1.1.0 && < 1.4
-    - text >= 1.2.3.1 && < 1.3
+    - text >= 1.2.3.1 && < 2.1
     - time >= 1.8.0.2 && < 1.12
 
 tests:

--- a/toml-reader.cabal
+++ b/toml-reader.cabal
@@ -55,7 +55,7 @@ library
     , containers >=0.6.0.1 && <0.7
     , megaparsec >=7.0.5 && <9.3
     , parser-combinators >=1.1.0 && <1.4
-    , text >=1.2.3.1 && <1.3
+    , text >=1.2.3.1 && <2.1
     , time >=1.8.0.2 && <1.12
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances


### PR DESCRIPTION
I tried building with GHC 9.4 but it comes with text 2.0.