### PR TITLE
Allow time 1.12.2

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,7 +32,7 @@ library:
     - megaparsec >= 7.0.5 && < 9.3
     - parser-combinators >= 1.1.0 && < 1.4
     - text >= 1.2.3.1 && < 2.1
-    - time >= 1.8.0.2 && < 1.12
+    - time >= 1.8.0.2 && < 1.13
 
 tests:
   toml-reader-tests:

--- a/toml-reader.cabal
+++ b/toml-reader.cabal
@@ -56,7 +56,7 @@ library
     , megaparsec >=7.0.5 && <9.3
     , parser-combinators >=1.1.0 && <1.4
     , text >=1.2.3.1 && <2.1
-    , time >=1.8.0.2 && <1.12.3
+    , time >=1.8.0.2 && <1.13
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
   default-language: Haskell2010

--- a/toml-reader.cabal
+++ b/toml-reader.cabal
@@ -56,7 +56,7 @@ library
     , megaparsec >=7.0.5 && <9.3
     , parser-combinators >=1.1.0 && <1.4
     , text >=1.2.3.1 && <2.1
-    , time >=1.8.0.2 && <1.12
+    , time >=1.8.0.2 && <1.12.3
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
   default-language: Haskell2010


### PR DESCRIPTION
Thank you for awesome modern toml tool !

```zsh
$ ghc --version                       
The Glorious Glasgow Haskell Compilation System, version 9.4.2
```

```.cabal
common common-all
    build-depends:
        base ^>=4.17.0.0,
        toml-reader ==0.1.0.0, 
    ghc-options:      -Wall
    default-language: Haskell2010
```

```zsh
$ cabal build --minimize-conflict-set
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: mklint-0.1.0.0 (user goal)
[__1] trying: mklint:*test
[__2] trying: hspec-2.10.6 (dependency of mklint *test)
[__3] trying: hspec-core-2.10.6 (dependency of hspec)
[__4] trying: ghc-9.4.2/installed-9.4.2 (dependency of hspec-core)
[__5] trying: unix-2.7.3/installed-2.7.3 (dependency of ghc)
[__6] trying: ghci-9.4.2/installed-9.4.2 (dependency of ghc)
[__7] next goal: toml-reader (dependency of mklint)
[__7] rejecting: toml-reader-0.1.0.0 (conflict: ghc =>
time==1.12.2/installed-1.12.2, toml-reader => time>=1.8.0.2 && <1.12)
[__7] fail (backjumping, conflict set: ghc, mklint, toml-reader)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: hspec, mklint, mklint:test, base,
hspec-core, ghc, ghci, unix, toml-reader
```