### PR TITLE
Bump time upper bound

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,7 @@ library:
     - megaparsec < 10
     - parser-combinators < 1.4
     - text < 3
-    - time < 1.13
+    - time < 1.15
 
 tests:
   toml-reader-tests:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.24
+resolver: lts-22.13
 
 ghc-options:
   '$locals': -Werror

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: e019cd29e3f7f9dbad500225829a3f7a50f73c674614f2f452e21bb8bf5d99ea
-    size: 650253
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/24.yaml
-  original: lts-20.24
+    sha256: 6f0bea3ba5b07360f25bc886e8cff8d847767557a492a6f7f6dcb06e3cc79ee9
+    size: 712905
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/13.yaml
+  original: lts-22.13

--- a/toml-reader.cabal
+++ b/toml-reader.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -56,7 +56,7 @@ library
     , megaparsec <10
     , parser-combinators <1.4
     , text <3
-    , time <1.13
+    , time <1.15
   default-language: Haskell2010
 
 test-suite parser-validator


### PR DESCRIPTION
Tested with
```
cabal test --constraint 'time==1.14' --allow-newer='*:time'
```