### PR TITLE
Propagating context through Map instances

### DIFF
--- a/src/TOML/Decode.hs
+++ b/src/TOML/Decode.hs
@@ -29,6 +29,7 @@ module TOML.Decode (
   getFieldOptWith,
   getFieldsOptWith,
   getArrayOf,
+  getTableOf,
 
   -- ** Build custom Decoder
   DecodeM (..),
@@ -600,7 +601,7 @@ instance (DecodeTOML a) => DecodeTOML (Monoid.Dual a) where
 instance (DecodeTOML a) => DecodeTOML [a] where
   tomlDecoder = getArrayOf tomlDecoder
 instance (IsString k, Ord k, DecodeTOML v) => DecodeTOML (Map k v) where
-  tomlDecoder = fmap (Map.mapKeys (fromString . Text.unpack)) $ getTableOf tomlDecoder
+  tomlDecoder = Map.mapKeys (fromString . Text.unpack) <$> getTableOf tomlDecoder
 instance (DecodeTOML a) => DecodeTOML (NonEmpty a) where
   tomlDecoder = maybe raiseEmpty pure . NonEmpty.nonEmpty =<< tomlDecoder
     where

--- a/test/tasty/TOML/DecodeTest.hs
+++ b/test/tasty/TOML/DecodeTest.hs
@@ -241,7 +241,7 @@ decoderInstanceTests =
         decodeWith (getField @(Int, Double) "a") "a = [1, 2.5]" @?= Right (1, 2.5)
     , testCase "Map" $
         decodeWith (getField @(Map Text.Text Int) "a") "a = {x = 1, y = 2}"
-          @?= Right (Map.fromList [("x",1), ("y",2)])
+          @?= Right (Map.fromList [("x", 1), ("y", 2)])
     , testCase "Tuples show errors with index" $
         case decodeWith (getField @(Int, Double) "a") "a = [1, true]" of
           Left (DecodeError [Key "a", Index 1] _) -> return ()

--- a/test/tasty/TOML/DecodeTest.hs
+++ b/test/tasty/TOML/DecodeTest.hs
@@ -5,6 +5,8 @@
 module TOML.DecodeTest (test) where
 
 import Data.Int (Int8)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import qualified Data.Time as Time
 import Numeric.Natural (Natural)
@@ -237,9 +239,16 @@ decoderInstanceTests =
         decodeWith (getField @() "a") "a = []" @?= Right ()
     , testCase "(a, b)" $
         decodeWith (getField @(Int, Double) "a") "a = [1, 2.5]" @?= Right (1, 2.5)
+    , testCase "Map" $
+        decodeWith (getField @(Map Text.Text Int) "a") "a = {x = 1, y = 2}"
+          @?= Right (Map.fromList [("x",1), ("y",2)])
     , testCase "Tuples show errors with index" $
         case decodeWith (getField @(Int, Double) "a") "a = [1, true]" of
           Left (DecodeError [Key "a", Index 1] _) -> return ()
+          result -> unexpectedResult result
+    , testCase "Maps show errors with key" $
+        case decodeWith (getField @(Map Text.Text Int) "a") "a = {x = true}" of
+          Left (DecodeError [Key "a", Key "x"] _) -> return ()
           result -> unexpectedResult result
     ]
   where


### PR DESCRIPTION
We introduce a new function 'getTableOf' by analogy with 'getArrayOf'. We also add two new tests.

This is intended to solve [issue #32](https://github.com/brandonchinn178/toml-reader/issues/32).