### PR TITLE
Drop support for GHC < 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,11 @@ jobs:
     strategy:
       matrix:
         ghc_version:
-          - '9.0'
-          - '9.2'
-          - '9.4'
-          - '9.6'
           - '9.8'
           - '9.10'
           - '9.12'
         include:
-          - ghc_version: '9.0'
+          - ghc_version: '9.8'
             oldest: true
 
     name: ghc_compat_test (${{ matrix.ghc_version }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Drop support for GHC < 9.8
+
 ## v0.2.2.0
 
 * Add support for GHC 9.10 + 9.12

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ ghc-options:
   - -Wincomplete-uni-patterns
   - -Wnoncanonical-monad-instances
   - -Wunused-packages
+default-language: GHC2021
 
 library:
   source-dirs: src

--- a/src/TOML/Decode.hs
+++ b/src/TOML/Decode.hs
@@ -52,30 +52,30 @@ import Data.Fixed (Fixed, HasResolution)
 import Data.Functor.Identity (Identity (..))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
+import Data.IntMap qualified as IntMap
 import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
+import Data.IntSet qualified as IntSet
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
-import qualified Data.Monoid as Monoid
+import Data.Monoid qualified as Monoid
 import Data.Proxy (Proxy (..))
 import Data.Ratio (Ratio)
-import qualified Data.Semigroup as Semigroup
+import Data.Semigroup qualified as Semigroup
 import Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
+import Data.Sequence qualified as Seq
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.String (IsString, fromString)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-import qualified Data.Text.Lazy as Lazy (Text)
-import qualified Data.Text.Lazy as Text.Lazy
-import qualified Data.Time as Time
-import qualified Data.Time.Clock.System as Time
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
+import Data.Text.Lazy qualified as Lazy (Text)
+import Data.Text.Lazy qualified as Text.Lazy
+import Data.Time qualified as Time
+import Data.Time.Clock.System qualified as Time
 import Data.Version (Version, parseVersion)
 import Data.Void (Void)
 import Data.Word (Word16, Word32, Word64, Word8)

--- a/src/TOML/Error.hs
+++ b/src/TOML/Error.hs
@@ -13,9 +13,9 @@ module TOML.Error (
 
 import Control.Exception (Exception (..))
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 import TOML.Value (Table, Value (..), renderValue)
 

--- a/src/TOML/Parser.hs
+++ b/src/TOML/Parser.hs
@@ -28,19 +28,19 @@ import Data.Foldable (foldl')
 #endif
 import Data.Functor (($>))
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Time (Day, LocalTime, TimeOfDay, TimeZone)
-import qualified Data.Time as Time
+import Data.Time qualified as Time
 import Data.Void (Void)
-import qualified Numeric
+import Numeric qualified
 import Text.Megaparsec hiding (sepBy1)
 import Text.Megaparsec.Char hiding (space, space1)
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 import TOML.Error (NormalizeError (..), TOMLError (..))
 import TOML.Utils.Map (getPathLens)

--- a/src/TOML/Utils/Map.hs
+++ b/src/TOML/Utils/Map.hs
@@ -8,7 +8,7 @@ module TOML.Utils.Map (
 import Data.Foldable (foldlM)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 
 import TOML.Utils.NonEmpty (zipHistory)
 

--- a/src/TOML/Utils/NonEmpty.hs
+++ b/src/TOML/Utils/NonEmpty.hs
@@ -6,7 +6,7 @@ module TOML.Utils.NonEmpty (
 
 import Data.List (scanl')
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 
 -- |
 -- Annotates each element with the history of all past elements.

--- a/src/TOML/Value.hs
+++ b/src/TOML/Value.hs
@@ -8,9 +8,9 @@ module TOML.Value (
 ) where
 
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Time (Day, LocalTime, TimeOfDay, TimeZone)
 
 type Table = Map Text Value

--- a/test/tasty/Main.hs
+++ b/test/tasty/Main.hs
@@ -1,10 +1,10 @@
 import Test.Tasty
 
-import qualified TOML.DecodeTest
-import qualified TOML.ErrorTest
-import qualified TOML.ParserTest
-import qualified TOML.Utils.MapTest
-import qualified TOML.Utils.NonEmptyTest
+import TOML.DecodeTest qualified
+import TOML.ErrorTest qualified
+import TOML.ParserTest qualified
+import TOML.Utils.MapTest qualified
+import TOML.Utils.NonEmptyTest qualified
 
 main :: IO ()
 main =

--- a/test/tasty/TOML/DecodeTest.hs
+++ b/test/tasty/TOML/DecodeTest.hs
@@ -6,9 +6,9 @@ module TOML.DecodeTest (test) where
 
 import Data.Int (Int8)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as Text
-import qualified Data.Time as Time
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as Text
+import Data.Time qualified as Time
 import Numeric.Natural (Natural)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit

--- a/test/tasty/TOML/ErrorTest.hs
+++ b/test/tasty/TOML/ErrorTest.hs
@@ -3,11 +3,11 @@
 module TOML.ErrorTest (test) where
 
 import Control.Monad (unless)
-import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as Text
-import qualified Data.Text.Lazy as TextL
-import qualified Data.Text.Lazy.Encoding as TextL
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as Text
+import Data.Text.Lazy qualified as TextL
+import Data.Text.Lazy.Encoding qualified as TextL
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden
 import Test.Tasty.HUnit

--- a/test/tasty/TOML/ParserTest.hs
+++ b/test/tasty/TOML/ParserTest.hs
@@ -2,7 +2,7 @@
 
 module TOML.ParserTest (test) where
 
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
 

--- a/test/tasty/TOML/Utils/MapTest.hs
+++ b/test/tasty/TOML/Utils/MapTest.hs
@@ -3,9 +3,9 @@
 module TOML.Utils.MapTest (test) where
 
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
 

--- a/test/tasty/TOML/Utils/NonEmptyTest.hs
+++ b/test/tasty/TOML/Utils/NonEmptyTest.hs
@@ -1,6 +1,6 @@
 module TOML.Utils.NonEmptyTest (test) where
 
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
 

--- a/test/toml-test/ValidateParser.hs
+++ b/test/toml-test/ValidateParser.hs
@@ -3,15 +3,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Data.Aeson ((.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy.Char8 as Char8
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy.Char8 qualified as Char8
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 import Data.Time (ZonedTime (..))
-import qualified Data.Vector as Vector
+import Data.Vector qualified as Vector
 import System.Directory (findExecutable)
 import System.Environment (getArgs, getExecutablePath)
 import System.Exit (exitFailure)

--- a/toml-reader.cabal
+++ b/toml-reader.cabal
@@ -57,7 +57,7 @@ library
     , parser-combinators
     , text
     , time
-  default-language: Haskell2010
+  default-language: GHC2021
 
 test-suite parser-validator
   type: exitcode-stdio-1.0
@@ -79,7 +79,7 @@ test-suite parser-validator
     , toml-reader
     , unordered-containers
     , vector
-  default-language: Haskell2010
+  default-language: GHC2021
 
 test-suite toml-reader-tests
   type: exitcode-stdio-1.0
@@ -103,4 +103,4 @@ test-suite toml-reader-tests
     , text
     , time
     , toml-reader
-  default-language: Haskell2010
+  default-language: GHC2021


### PR DESCRIPTION
No need to support old versions. People running on old versions could use the versions of toml-reader that already exist